### PR TITLE
Fixes #4911: exclude asm 4 from specs 2 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,6 +353,12 @@ limitations under the License.
       <artifactId>specs2_${scala-binary-version}</artifactId>
       <version>${specs2-version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.ow2.asm</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <!-- 


### PR DESCRIPTION
Exclude asm 4 dependencies from specs2. I haven't seen any problem with tests so far ...

http://www.rudder-project.org/redmine/issues/4911
